### PR TITLE
Fix reference path alignment: headings, block reflow, and scrolling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ### Fixed
  - the reference path line is now aligned with the bullet on heading blocks (h1/h2/h3) and on blocks with tall content (embeds/images). The line offset and endpoints are measured from the actual bullet elements instead of a fixed constant that assumed a single-line text block. This also removes the need for the Roam-Studio-specific offset constants.
- - adding the reference path no longer reflows the block. The connector is anchored to the bullet's real containing block without changing any element's `position` (an earlier approach forced position:relative on the bullet, which Roam positions absolutely in the gutter, pushing the block text to the right).
+ - adding the reference path no longer reflows the block. Two things caused it: (1) the connector forced position:relative on the bullet, which Roam positions absolutely in the gutter, pushing the block text right — the connector is now anchored to the bullet's real containing block without changing any element's `position`; (2) references in a path block were bolded (font-weight), and bolder text is wider, so a reference near a line-wrap boundary pushed text onto another line — references are now emphasised with colour only.
+
+### Removed
+ - the "References: font weight" setting. Bolding references changes their width and reflows the block; the colour emphasis alone marks them without moving anything.
  - the reference path line no longer drifts out of alignment after scrolling. It is measured with getBoundingClientRect, so it is now recomputed on scroll (throttled to one redraw per animation frame) while a block is being edited.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ### Fixed
  - the reference path line is now aligned with the bullet on heading blocks (h1/h2/h3) and on blocks with tall content (embeds/images). The line offset and endpoints are measured from the actual bullet elements instead of a fixed constant that assumed a single-line text block. This also removes the need for the Roam-Studio-specific offset constants.
+ - the reference path line no longer drifts out of alignment after scrolling. It is measured with getBoundingClientRect, so it is now recomputed on scroll (throttled to one redraw per animation frame) while a block is being edited.
 
 ### Added
- - automated regression test (Playwright + a synthetic Roam DOM fixture) covering the connector alignment for heading and normal blocks: `npm test`
+ - automated regression tests (Playwright + synthetic Roam DOM fixtures) covering connector alignment on heading/normal blocks and recomputation on scroll: `npm test`
 
 ## [1] -- 2022-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ### Fixed
  - the reference path line is now aligned with the bullet on heading blocks (h1/h2/h3) and on blocks with tall content (embeds/images). The line offset and endpoints are measured from the actual bullet elements instead of a fixed constant that assumed a single-line text block. This also removes the need for the Roam-Studio-specific offset constants.
+ - adding the reference path no longer reflows the block. The connector is anchored to the bullet's real containing block without changing any element's `position` (an earlier approach forced position:relative on the bullet, which Roam positions absolutely in the gutter, pushing the block text to the right).
  - the reference path line no longer drifts out of alignment after scrolling. It is measured with getBoundingClientRect, so it is now recomputed on scroll (throttled to one redraw per animation frame) while a block is being edited.
 
 ### Added
- - automated regression tests (Playwright + synthetic Roam DOM fixtures) covering connector alignment on heading/normal blocks and recomputation on scroll: `npm test`
+ - automated regression tests (Playwright + synthetic Roam DOM fixtures) covering connector alignment on heading/normal blocks, no-reflow on highlight, and recomputation on scroll: `npm test`
 
 ## [1] -- 2022-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+
+### Fixed
+ - the reference path line is now aligned with the bullet on heading blocks (h1/h2/h3) and on blocks with tall content (embeds/images). The line offset and endpoints are measured from the actual bullet elements instead of a fixed constant that assumed a single-line text block. This also removes the need for the Roam-Studio-specific offset constants.
+
+### Added
+ - automated regression test (Playwright + a synthetic Roam DOM fixture) covering the connector alignment for heading and normal blocks: `npm test`
+
 ## [1] -- 2022-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ If both modes are enabled, hover mode works only when there is no block being ed
 This extension was carefully tested with the default Roam theme and with Roam Studio. It should be possible to use it safely with other extensions or custom themes available in Roam Depot. If you notice any incompatibility with other extensions, please open an issue on github so that it can be fixed.
 
 
+## Development / tests
+
+There is no build step: `extension.js` is loaded directly by Roam Depot.
+
+Automated tests use [Playwright](https://playwright.dev/) against a synthetic Roam DOM fixture (no Roam login required), verifying that the reference-path connector stays aligned with the bullet on heading and normal blocks. Real browser layout is required (`getBoundingClientRect`), so the tests run in Chrome:
+
+```
+npm install
+npm test
+```
+
+The tests use the locally installed Google Chrome (`channel: 'chrome'`), so no browser download is needed.
+
+
 ## Future improvements
 - document the available options (or at least show a printscreen of the settings screen)
 - review the extension name: "reference path" is also used in Settings -> User (in the context of block references), so it can be confusing.

--- a/extension.js
+++ b/extension.js
@@ -693,17 +693,57 @@ function startTemporaryObserver ({ target }) {
 
 	let { observer, observerId } = startObserver({ target, callback: temporaryObserverCallback, options });
 
-	internals.cleaners.push({ 
+	// the reference path line is positioned from getBoundingClientRect measurements
+	// taken at draw time; scrolling does not trigger a DOM mutation, so without this
+	// the line drifts out of alignment with the bullets after the page is scrolled.
+	// recompute it (throttled to one redraw per frame) while a path is shown.
+
+	let scrollRedrawScheduled = false;
+
+	let onScroll = function onScroll () {
+
+		if (scrollRedrawScheduled) { return }
+		if (blockList.length === 0) { return }  // no path currently shown for this target
+
+		scrollRedrawScheduled = true;
+
+		requestAnimationFrame(function redrawOnScroll () {
+
+			scrollRedrawScheduled = false;
+
+			if (blockList.length === 0) { return }
+
+			// redraw from the block currently being edited (its textarea), or from the
+			// focused code block; anything else means there is nothing to keep aligned
+
+			if (textareaLiveList.length > 0) {
+				removeReferencePath(blockList);
+				addReferencePath(blockList, textareaLiveList.item(0));
+			}
+			else if (document.activeElement != null && document.activeElement.className.includes('cm-content') && target.contains(document.activeElement)) {
+				removeReferencePath(blockList);
+				addReferencePath(blockList, document.activeElement);
+			}
+		});
+	};
+
+	// scroll events do not bubble, but a capture-phase listener on window catches
+	// scrolling from any scroll container in the page (main view and sidebar)
+
+	window.addEventListener('scroll', onScroll, { capture: true, passive: true });
+
+	internals.cleaners.push({
 		observerId,
-		handler: () => { 
+		handler: () => {
 
 			log('cleaner for temporary observer', { observerId });
 
 			observer.disconnect();
+			window.removeEventListener('scroll', onScroll, true);
 			delete target.dataset.referencePathObserverId;  // might not work in safari <= 10?
 			removeReferencePath(blockList);
 			removeMouseHoverListeners(target);
-		} 
+		}
 	});
 
 	// initialize the hover behaviours; note that addMouseHoverListeners is also called in the temporary 
@@ -1101,9 +1141,9 @@ export default {
 	onunload
 };
 
-// named exports used only by the automated test harness (test/reference-path.spec.js);
+// named exports used only by the automated test harness (test/*.spec.js);
 // Roam Depot loads the default export, so these have no effect on the extension at runtime
-export { addReferencePath, removeReferencePath, addStyle, internals };
+export { addReferencePath, removeReferencePath, addStyle, startTemporaryObserver, stopObserver, internals };
 
 
 // https://tailwindcss.com/docs/customizing-colors

--- a/extension.js
+++ b/extension.js
@@ -20,7 +20,6 @@ internals.settingsCached = {
 	bulletScaleFactor: null,
 
 	referenceColorShade: null,
-	referenceFontWeightDescription: null,
 
 	lineColorShade: null,
 	lineWidth: null,
@@ -39,8 +38,6 @@ internals.settingsCached = {
 	bulletColorHoverHex: null,  // derived from bulletColorHex
 	referenceColorHoverHex: null,  // derived from colreferenceColorHex
 	lineColorHoverHex: null,  // derived frolineColorHex
-
-	referenceFontWeightValue: null,  // derived from referenceFontWeightDescription
 };
 
 internals.settingsDefault = {
@@ -50,7 +47,6 @@ internals.settingsDefault = {
 	bulletScaleFactor: '1.5',
 	
 	referenceColorShade: '500',
-	referenceFontWeightDescription: 'medium',
 
 	lineColorShade: '500',
 	lineWidth: '1px',
@@ -215,18 +211,6 @@ function initializeSettings() {
 	});
 
 	panelConfig.settings.push({
-		id: 'referenceFontWeightDescription',
-		name: 'References (double brackets and tags): font weight',
-		// description: 'Make the references that belong to blocks in the active path stand out.',
-		action: {
-			type: 'select',
-			// weight names corresponding to ['300', '400', '500', '600', '700']
-			items: ['disabled', 'light', 'normal', 'medium', 'semibold', 'bold'],
-			onChange: value => { updateSettingsCached({ key: 'referenceFontWeightDescription', value }) },
-		},
-	});
-
-	panelConfig.settings.push({
 		id: 'lineColorShade',
 		name: 'Lines: color shade',
 		description: 'See the description given for bullets. If this setting is disabled, the remaining settings for lines will also be disabled.',
@@ -346,7 +330,7 @@ function updateSettingsCached({ key, value, resetStyle: _resetStyle }) {
 
 	// derived settings
 
-	let { bulletColorShade, referenceColorShade, lineColorShade, referenceFontWeightDescription } = internals.settingsCached;
+	let { bulletColorShade, referenceColorShade, lineColorShade } = internals.settingsCached;
 
 	internals.settingsCached.bulletColorHex = getColorHex({ shade: bulletColorShade });
 	internals.settingsCached.referenceColorHex = getColorHex({ shade: referenceColorShade });
@@ -356,8 +340,6 @@ function updateSettingsCached({ key, value, resetStyle: _resetStyle }) {
 	internals.settingsCached.referenceColorHoverHex = getShadeAndTint(internals.settingsCached.referenceColorHex, 4).tint;
 	internals.settingsCached.lineColorHoverHex = getShadeAndTint(internals.settingsCached.lineColorHex, 4).tint;
 
-	internals.settingsCached.referenceFontWeightValue = getFontWeightValue({ fontWeightDescription: referenceFontWeightDescription });
-	
 	// styles are reseted here, unless we explicitly turn it off
 
 	if (_resetStyle !== false) {
@@ -389,22 +371,6 @@ function getColorHex({ shade }) {
 	let colorHex = internals.tailwindColors[color][shadeIdx];
 
 	return colorHex;
-}
-
-function getFontWeightValue({ fontWeightDescription }) {
-
-	// https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#common_weight_name_mapping
-
-	let nameToValue = {
-		'light': '300',
-		'normal': '400',
-		'medium': '500',
-		'semibold': '600',
-		'bold': '700',
-		'disabled': 'disabled'
-	}
-
-	return nameToValue[fontWeightDescription];
 }
 
 function resetStyle() {
@@ -465,21 +431,9 @@ function addStyle() {
 		`;
 	}
 
-	if (internals.settingsCached.referenceFontWeightValue !== 'disabled') {
-		textContent += `
-			[data-reference-path-has-style] > div.rm-block-text span.rm-page-ref__brackets {
-				font-weight:  var(--${extensionId}-brackets-weight);
-			}
-
-			[data-reference-path-has-style] > div.rm-block-text span.rm-page-ref--link {
-				font-weight:  var(--${extensionId}-link-weight);
-			}
-
-			[data-reference-path-has-style] > div.rm-block-text span.rm-page-ref--tag {
-				font-weight:  var(--${extensionId}-link-weight);
-			}
-		`;
-	}
+	// note: the references in a path block are emphasised with colour only. font-weight
+	// was intentionally dropped: bolder text is wider, so it reflowed the block (pushing
+	// text onto another line) whenever a reference sat near a line-wrap boundary.
 
 	if (internals.settingsCached.lineColorHex !== 'disabled') {
 		textContent += `
@@ -762,7 +716,7 @@ function addReferencePath(blockList, el, isHover = false) {
 
 	let { extensionId } = internals;
 	let { bulletColorHex, bulletColorHoverHex, bulletScaleFactor } = internals.settingsCached;
-	let { referenceColorHex, referenceColorHoverHex, referenceFontWeightValue } = internals.settingsCached;
+	let { referenceColorHex, referenceColorHoverHex } = internals.settingsCached;
 	let { lineColorHex, lineColorHoverHex, lineRoundness, lineWidth, lineStyle, lineTopOffset, lineLeftOffset } = internals.settingsCached;
 	let blockPrevious = null;
 
@@ -840,11 +794,6 @@ function addReferencePath(blockList, el, isHover = false) {
 		if (referenceColorHex !== 'disabled') {
 			blockEl.style.setProperty(`--${extensionId}-brackets-color`, isHover ? referenceColorHoverHex : referenceColorHex);
 			blockEl.style.setProperty(`--${extensionId}-link-color`, isHover ? referenceColorHoverHex : referenceColorHex);
-		}
-
-		if (referenceFontWeightValue !== 'disabled') {
-			blockEl.style.setProperty(`--${extensionId}-brackets-weight`, referenceFontWeightValue);
-			blockEl.style.setProperty(`--${extensionId}-link-weight`, referenceFontWeightValue);
 		}
 
 		if (lineColorHex !== 'disabled') {
@@ -951,9 +900,7 @@ function removeReferencePath(blockList) {
 		blockEl.style.removeProperty(`--${extensionId}-bullet-color`);
 		
 		blockEl.style.removeProperty(`--${extensionId}-brackets-color`);
-		blockEl.style.removeProperty(`--${extensionId}-brackets-weight`);
 		blockEl.style.removeProperty(`--${extensionId}-link-color`);
-		blockEl.style.removeProperty(`--${extensionId}-link-weight`);
 
 		blockEl.style.removeProperty(`--${extensionId}-line-color`);
 		blockEl.style.removeProperty(`--${extensionId}-line-roundness`);

--- a/extension.js
+++ b/extension.js
@@ -284,7 +284,7 @@ function initializeSettings() {
 	panelConfig.settings.push({
 		id: 'lineTopOffset',
 		name: 'Lines: top offset (ADVANCED)',
-		description: 'Use a value different from auto only if the line seems out of place vertically. Recommended values are between 9.5px and 10.5px (depends on the line width).',
+		description: 'Leave as auto: the offset is measured automatically from the bullet, so the line stays aligned on headings and tall blocks. Use an explicit value only if the line still seems out of place vertically.',
 		action: {
 			type: 'select',
 			items: ['auto', '6.5px', '7.0px', '7.5px', '8px', '8.5px', '9px', '9.5px', '10px', '10.5px', '11px', '11.5px', '12.0px', '12.5px'],
@@ -295,7 +295,7 @@ function initializeSettings() {
 	panelConfig.settings.push({
 		id: 'lineLeftOffset',
 		name: 'Lines: left offset (ADVANCED)',
-		description: 'Use a value different from auto only if the line seems out of place horizontally. Recommended values are between 5px and 6px (depends on the line width).',
+		description: 'Leave as auto: the offset is measured automatically from the bullet. Use an explicit value only if the line seems out of place horizontally.',
 		action: {
 			type: 'select',
 			items: ['auto', '3.5px', '4px', '4.5px', '5px', '5.5px', '6px', '6.5px', '7px', '7.5px', '8px', '8.5px'],
@@ -483,6 +483,10 @@ function addStyle() {
 
 	if (internals.settingsCached.lineColorHex !== 'disabled') {
 		textContent += `
+			[data-reference-path-has-style] > div.controls span.bp3-popover-target {
+				position: relative;
+			}
+
 			[data-reference-path-has-style] > div.controls span.bp3-popover-target::before {
 				border-color: var(--${extensionId}-line-color);
 				border-width: var(--${extensionId}-line-width);
@@ -726,15 +730,8 @@ function addReferencePath(blockList, el, isHover = false) {
 	let { lineColorHex, lineColorHoverHex, lineRoundness, lineWidth, lineStyle, lineTopOffset, lineLeftOffset } = internals.settingsCached;
 	let blockPrevious = null;
 
-	if (lineColorHex !== 'disabled') {
-		if (lineTopOffset === 'auto') {
-			lineTopOffset = getLineTopOffsetAuto(lineWidth);
-		}
-
-		if (lineLeftOffset === 'auto') {
-			lineLeftOffset = getLineLeftOffsetAuto(lineWidth);
-		}
-	}
+	// note: when lineTopOffset/lineLeftOffset are 'auto' they are resolved per-block
+	// inside the loop, using the measured bullet geometry (see below)
 
 	let iterationCount = 0, iterationLimit = 99;
 	for(;;) {
@@ -830,30 +827,54 @@ function addReferencePath(blockList, el, isHover = false) {
 			else {
 				// reference: https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
 
-				let bboxCurrent = blockEl.getBoundingClientRect()
-				let bboxPrevious = blockPrevious.getBoundingClientRect()
+				// measure the actual bullet elements instead of the block's top-left corner
+				// plus a fixed offset; this keeps the connector aligned regardless of block
+				// height - in particular for heading blocks (h1/h2/h3) and blocks with tall
+				// embeds/images, where the bullet centre is far from `blockTop + <constant>`
 
-				// normally we have boxWidth > 0 and boxHeight > 0, but there are some cases in which 
-				// boxHeight is 0 (embedded blocks)
+				let parentBullet = blockEl.querySelector('span.bp3-popover-target');
+				let childBullet = blockPrevious.querySelector('span.bp3-popover-target');
 
-				// TODO: in RTL languages this logic must be inverted somehow
+				if (parentBullet != null && childBullet != null) {
 
-				let boxWidthNumeric = bboxPrevious.x - bboxCurrent.x;
-				let boxHeightNumeric = bboxPrevious.y - bboxCurrent.y;
+					let parentBox = parentBullet.getBoundingClientRect();
+					let childBox = childBullet.getBoundingClientRect();
 
-				if (boxWidthNumeric > 0 && boxHeightNumeric > 0) {
-					blockEl.style.setProperty(`--${extensionId}-line-width`, `${lineWidth}`);
-					blockEl.style.setProperty(`--${extensionId}-line-color`, isHover ? lineColorHoverHex : lineColorHex);
-					blockEl.style.setProperty(`--${extensionId}-line-style`, lineStyle);
-					blockEl.style.setProperty(`--${extensionId}-line-roundness`, `${lineRoundness}`);
-					blockEl.style.setProperty(`--${extensionId}-line-top-offset`, `${lineTopOffset}`);
-					blockEl.style.setProperty(`--${extensionId}-line-left-offset`, `${lineLeftOffset}`);
+					let parentCenterX = parentBox.x + parentBox.width / 2;
+					let parentCenterY = parentBox.y + parentBox.height / 2;
+					let childCenterX = childBox.x + childBox.width / 2;
+					let childCenterY = childBox.y + childBox.height / 2;
 
-					let boxWidth = `${boxWidthNumeric}px`;
-					let boxHeight = `${boxHeightNumeric}px`;
+					// the connector goes from the parent bullet centre down/right to the child
+					// bullet centre; the ::before is positioned relative to the parent bullet
+					// (addStyle marks span.bp3-popover-target as position:relative)
 
-					blockEl.style.setProperty(`--${extensionId}-box-width`, `${boxWidth}`);
-					blockEl.style.setProperty(`--${extensionId}-box-height`, `${boxHeight}`);			
+					let boxWidthNumeric = childCenterX - parentCenterX;
+					let boxHeightNumeric = childCenterY - parentCenterY;
+
+					// normally we have boxWidth > 0 and boxHeight > 0, but there are some cases in which
+					// boxHeight is 0 (embedded blocks)
+
+					// TODO: in RTL languages this logic must be inverted somehow
+
+					if (boxWidthNumeric > 0 && boxHeightNumeric > 0) {
+
+						// 'auto' anchors the connector corner at the parent bullet centre; an
+						// explicit value (the ADVANCED settings) still overrides it for fine tuning
+
+						let topOffset = (lineTopOffset === 'auto') ? `${parentBox.height / 2}px` : lineTopOffset;
+						let leftOffset = (lineLeftOffset === 'auto') ? `${parentBox.width / 2}px` : lineLeftOffset;
+
+						blockEl.style.setProperty(`--${extensionId}-line-width`, `${lineWidth}`);
+						blockEl.style.setProperty(`--${extensionId}-line-color`, isHover ? lineColorHoverHex : lineColorHex);
+						blockEl.style.setProperty(`--${extensionId}-line-style`, lineStyle);
+						blockEl.style.setProperty(`--${extensionId}-line-roundness`, `${lineRoundness}`);
+						blockEl.style.setProperty(`--${extensionId}-line-top-offset`, topOffset);
+						blockEl.style.setProperty(`--${extensionId}-line-left-offset`, leftOffset);
+
+						blockEl.style.setProperty(`--${extensionId}-box-width`, `${boxWidthNumeric}px`);
+						blockEl.style.setProperty(`--${extensionId}-box-height`, `${boxHeightNumeric}px`);
+					}
 				}
 			}
 		}
@@ -906,37 +927,6 @@ function removeReferencePath(blockList) {
 	blockList.length = 0;
 }
 
-function getLineTopOffsetAuto(lineWidth) {
-
-	lineWidth = parseFloat(lineWidth);
-	let lineTopOffset = '';
-
-	if (internals.installedExtensions.roamStudio) {
-		if (lineWidth === 1) {
-			lineTopOffset = '7.0px';
-		}
-		else if (lineWidth === 2) {
-			lineTopOffset = '7.5px';
-		}
-		else if (lineWidth === 3) {
-			lineTopOffset = '8.0px';
-		}		
-	}
-	else {
-		if (lineWidth === 1) {
-			lineTopOffset = '9.5px';
-		}
-		else if (lineWidth === 2) {
-			lineTopOffset = '10px';
-		}
-		else if (lineWidth === 3) {
-			lineTopOffset = '10.5px';
-		}		
-	}
-
-	return lineTopOffset;
-}
-
 function getTargetKey({ target }) {
 
 	let targetKey = '';
@@ -952,24 +942,6 @@ function getTargetKey({ target }) {
 	}
 
 	return targetKey;
-}
-
-function getLineLeftOffsetAuto(lineWidth, bulletScaleFactor) {
-
-	lineWidth = parseFloat(lineWidth);
-	let lineLeftOffset = '';
-
-	if (lineWidth === 1) {
-		lineLeftOffset = '6px';
-	}
-	else if (lineWidth === 2) {
-		lineLeftOffset = '5.5px';
-	}
-	else if (lineWidth === 3) {
-		lineLeftOffset = '5px';
-	}
-
-	return lineLeftOffset;
 }
 
 function startPermanentObserver({ target }) {
@@ -1128,6 +1100,10 @@ export default {
 	onload,
 	onunload
 };
+
+// named exports used only by the automated test harness (test/reference-path.spec.js);
+// Roam Depot loads the default export, so these have no effect on the extension at runtime
+export { addReferencePath, removeReferencePath, addStyle, internals };
 
 
 // https://tailwindcss.com/docs/customizing-colors

--- a/extension.js
+++ b/extension.js
@@ -483,10 +483,6 @@ function addStyle() {
 
 	if (internals.settingsCached.lineColorHex !== 'disabled') {
 		textContent += `
-			[data-reference-path-has-style] > div.controls span.bp3-popover-target {
-				position: relative;
-			}
-
 			[data-reference-path-has-style] > div.controls span.bp3-popover-target::before {
 				border-color: var(--${extensionId}-line-color);
 				border-width: var(--${extensionId}-line-width);
@@ -899,11 +895,20 @@ function addReferencePath(blockList, el, isHover = false) {
 
 					if (boxWidthNumeric > 0 && boxHeightNumeric > 0) {
 
-						// 'auto' anchors the connector corner at the parent bullet centre; an
-						// explicit value (the ADVANCED settings) still overrides it for fine tuning
+						// the ::before is absolutely positioned, so it is placed relative to its
+						// containing block: the bullet itself if Roam positions it (it does -
+						// the bullet is position:absolute in the gutter), otherwise the bullet's
+						// offset parent. we must NOT force position on the bullet here: overriding
+						// Roam's absolute bullet with position:relative pulls it back into the flow
+						// and reflows the whole block. instead we measure the real containing block
+						// and offset the connector corner to the parent bullet centre relative to it.
+						// 'auto' does this; an explicit value (the ADVANCED settings) still overrides it.
 
-						let topOffset = (lineTopOffset === 'auto') ? `${parentBox.height / 2}px` : lineTopOffset;
-						let leftOffset = (lineLeftOffset === 'auto') ? `${parentBox.width / 2}px` : lineLeftOffset;
+						let containingBlock = (getComputedStyle(parentBullet).position !== 'static') ? parentBullet : parentBullet.offsetParent;
+						let originRect = (containingBlock || blockEl).getBoundingClientRect();
+
+						let topOffset = (lineTopOffset === 'auto') ? `${parentCenterY - originRect.top}px` : lineTopOffset;
+						let leftOffset = (lineLeftOffset === 'auto') ? `${parentCenterX - originRect.left}px` : lineLeftOffset;
 
 						blockEl.style.setProperty(`--${extensionId}-line-width`, `${lineWidth}`);
 						blockEl.style.setProperty(`--${extensionId}-line-color`, isHover ? lineColorHoverHex : lineColorHex);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "roam-reference-path",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "roam-reference-path",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.48.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "roam-reference-path",
+  "version": "1.0.0",
+  "description": "A Roam Research extension that implements the reference path for the active block being edited.",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,21 @@
+const { defineConfig } = require('@playwright/test');
+
+// Uses the locally installed Google Chrome (channel: 'chrome') so no Chromium
+// download is required. Real browser layout is mandatory: getBoundingClientRect
+// returns zeros under jsdom, and this extension's whole job is geometry.
+module.exports = defineConfig({
+  testDir: './test',
+  fullyParallel: true,
+  reporter: [['list']],
+  use: {
+    channel: 'chrome',
+    headless: true,
+    baseURL: 'http://localhost:5599',
+  },
+  webServer: {
+    command: 'node test/static-server.mjs',
+    port: 5599,
+    reuseExistingServer: true,
+    stdout: 'pipe',
+  },
+});

--- a/test/fixtures/roam-layout.html
+++ b/test/fixtures/roam-layout.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>reference-path layout fixture</title>
+<style>
+  /* Models Roam: the bullet (span.bp3-popover-target) is position:absolute and
+     lives in the gutter, OUT of the text flow. If the extension forces
+     position:relative on it, the bullet is pulled back into the flow and pushes
+     the block text to the right (the reported "母block排版改变" bug). */
+  * { box-sizing: content-box; }
+  body { margin: 0; padding: 20px; font-family: sans-serif; }
+  .rm-block-children { margin-left: 24px; }
+  .rm-block-main { position: relative; }
+  .rm-block-main > .controls { display: inline-block; vertical-align: top; }
+  .controls span.bp3-popover-target {
+    position: absolute; left: 2px; top: 5px;
+    width: 12px; height: 12px;
+    display: inline-flex; align-items: center; justify-content: center;
+  }
+  .controls span.rm-bullet { display: flex; align-items: center; justify-content: center; width: 12px; height: 12px; }
+  .controls span.rm-bullet__inner { width: 6px; height: 6px; border-radius: 50%; background: #a3a3a3; }
+  .rm-block-text { display: inline; line-height: 20px; font-size: 14px; }
+</style>
+</head>
+<body>
+<div class="roam-main">
+ <div class="rm-article-wrapper">
+  <div class="roam-article">
+
+   <div class="roam-block-container">
+     <div class="rm-block-main" data-testid="parent"><div class="controls"><span class="bp3-popover-target"><span class="rm-bullet"><span class="rm-bullet__inner"></span></span></span></div><div class="rm-block-text" data-testid="parent-text">母 block 的一段文字，用来检测高亮后排版是否发生位移</div></div>
+     <div class="rm-block-children">
+       <div class="roam-block-container">
+         <div class="rm-block-main" data-testid="child"><div class="controls"><span class="bp3-popover-target"><span class="rm-bullet"><span class="rm-bullet__inner"></span></span></span></div><div class="rm-block-text" data-testid="child-text">子 block（被点击/编辑的块）</div></div>
+       </div>
+     </div>
+   </div>
+
+  </div>
+ </div>
+</div>
+
+<script type="module">
+  import { addReferencePath, removeReferencePath, addStyle, internals } from '/extension.js';
+  window.__rp = { addReferencePath, removeReferencePath, addStyle, internals };
+  window.__rpReady = true;
+</script>
+</body>
+</html>

--- a/test/fixtures/roam-outline.html
+++ b/test/fixtures/roam-outline.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>reference-path fixture</title>
+<style>
+  /* ---- minimal reproduction of Roam's outline layout ---------------------
+     The only properties that matter for this test are the ones that affect
+     bullet geometry: rm-block-main is a positioned flex row; the bullet
+     (span.bp3-popover-target) is vertically centered within the FIRST line's
+     box, whose height depends on the heading level. This is what makes a
+     heading block's bullet centre sit far below `blockTop + 9.5px` (the old
+     hard-coded offset) and is exactly the case the fix must handle. */
+  * { box-sizing: content-box; }
+  body { margin: 0; padding: 20px; font-family: sans-serif; }
+
+  .roam-block-container { }
+  .rm-block-children { margin-left: 24px; }
+
+  /* positioned row -> becomes the offsetParent of the ::before in the ORIGINAL
+     code (which does not position the bullet span). border/padding kept at 0 so
+     the border-box origin equals the padding-box origin used for absolute pos. */
+  .rm-block-main {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    padding: 0; border: 0; margin: 0;
+  }
+
+  /* controls column holds the bullet; its height == the first line box, so the
+     bullet is centred on the first line (like Roam). */
+  .rm-block-main > .controls {
+    flex: 0 0 12px;
+    width: 12px;
+    height: 20px;                /* normal block line box */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .rm-block-main.rm-heading-level-1 > .controls { height: 48px; }
+  .rm-block-main.rm-heading-level-2 > .controls { height: 40px; }
+
+  .controls span.bp3-popover-target {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+  }
+  .controls span.rm-bullet {
+    display: flex; align-items: center; justify-content: center;
+    width: 12px; height: 12px;
+  }
+  .controls span.rm-bullet__inner {
+    width: 6px; height: 6px; border-radius: 50%; background: #a3a3a3;
+  }
+
+  .rm-block-text { line-height: 20px; font-size: 14px; padding: 0; }
+  .rm-heading-level-1 .rm-block-text { line-height: 48px; font-size: 30px; font-weight: 700; }
+  .rm-heading-level-2 .rm-block-text { line-height: 40px; font-size: 22px; font-weight: 600; }
+
+  .tall-embed { width: 400px; height: 280px; background: #2b2b33; }
+</style>
+</head>
+<body>
+<div class="roam-main">
+ <div class="rm-article-wrapper">
+  <div class="roam-article">
+
+   <!-- L1: CH2 (H1 heading) -->
+   <div class="roam-block-container">
+     <div class="rm-block-main rm-heading-level-1" data-testid="ch2">
+       <div class="controls"><span class="bp3-popover-target"><span class="rm-bullet"><span class="rm-bullet__inner"></span></span></span></div>
+       <div class="rm-block-text">CH2 卡片大法</div>
+     </div>
+     <div class="rm-block-children">
+
+       <!-- L2: a tall embedded-image block (sibling, NOT on the path) that pushes
+            the next sibling far down, reproducing the large vertical gap in the
+            user's screenshot -->
+       <div class="roam-block-container">
+         <div class="rm-block-main rm-heading-level-2" data-testid="img">
+           <div class="controls"><span class="bp3-popover-target"><span class="rm-bullet"><span class="rm-bullet__inner"></span></span></span></div>
+           <div class="rm-block-text">写作的四则运算<div class="tall-embed"></div></div>
+         </div>
+       </div>
+
+       <!-- L2: 卡片拼接 (H2 heading) -- on the path -->
+       <div class="roam-block-container">
+         <div class="rm-block-main rm-heading-level-2" data-testid="pinjie">
+           <div class="controls"><span class="bp3-popover-target"><span class="rm-bullet"><span class="rm-bullet__inner"></span></span></span></div>
+           <div class="rm-block-text">卡片拼接：从卡片到文章</div>
+         </div>
+         <div class="rm-block-children">
+
+           <!-- L3: 卡片扩写 (normal block) -->
+           <div class="roam-block-container">
+             <div class="rm-block-main" data-testid="kuoxie">
+               <div class="controls"><span class="bp3-popover-target"><span class="rm-bullet"><span class="rm-bullet__inner"></span></span></span></div>
+               <div class="rm-block-text">卡片扩写实现从一个词汇到一个段落，卡片拼接则是从卡片到文章。</div>
+             </div>
+             <div class="rm-block-children">
+
+               <!-- L4: normal grandchild -- the ACTIVE / edited block. Gives a
+                    normal->normal hop (the previously-working common case) as a
+                    no-regression control alongside the heading hops. -->
+               <div class="roam-block-container">
+                 <div class="rm-block-main" data-testid="xijie">
+                   <div class="controls"><span class="bp3-popover-target"><span class="rm-bullet"><span class="rm-bullet__inner"></span></span></span></div>
+                   <div class="rm-block-text" data-testid="active-text">基础拼接：并列；推进</div>
+                 </div>
+               </div>
+
+             </div>
+           </div>
+
+         </div>
+       </div>
+
+     </div>
+   </div>
+
+  </div>
+ </div>
+</div>
+
+<script type="module">
+  // expose the real extension functions for the Playwright test
+  import { addReferencePath, removeReferencePath, addStyle, internals } from '/extension.js';
+  window.__rp = { addReferencePath, removeReferencePath, addStyle, internals };
+  window.__rpReady = true;
+</script>
+</body>
+</html>

--- a/test/fixtures/roam-refs.html
+++ b/test/fixtures/roam-refs.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>reference-path refs/reflow fixture</title>
+<style>
+  * { box-sizing: content-box; }
+  body { margin: 0; padding: 20px; font-family: sans-serif; }
+  .rm-block-children { margin-left: 24px; }
+  .rm-block-main { position: relative; }
+  .rm-block-main > .controls { display: inline-block; vertical-align: top; }
+  .controls span.bp3-popover-target {
+    position: absolute; left: 2px; top: 5px; width: 12px; height: 12px;
+    display: inline-flex; align-items: center; justify-content: center;
+  }
+  .controls span.rm-bullet { display: flex; align-items: center; justify-content: center; width: 12px; height: 12px; }
+  .controls span.rm-bullet__inner { width: 6px; height: 6px; border-radius: 50%; background: #a3a3a3; }
+  /* fixed width so a width change in the content reflows to another line */
+  .rm-block-text { display: inline-block; width: 460px; line-height: 24px; font-size: 15px; vertical-align: top; }
+  .rm-page-ref--link, .rm-page-ref--tag { color: #106ba3; }
+  .rm-page-ref__brackets { color: #a7b6c2; }
+</style>
+</head>
+<body>
+<div class="roam-main">
+ <div class="rm-article-wrapper">
+  <div class="roam-article">
+
+   <div class="roam-block-container">
+     <div class="rm-block-main" data-testid="parent"><div class="controls"><span class="bp3-popover-target"><span class="rm-bullet"><span class="rm-bullet__inner"></span></span></span></div><div class="rm-block-text" data-testid="parent-text">cd到 essays/physical-therapy-exercise/ ，和cc讨论，制定一下 <span class="rm-page-ref__brackets">[[</span><span class="rm-page-ref rm-page-ref--link" data-testid="ref">Fitness (健身)</span><span class="rm-page-ref__brackets">]]</span> 计划，和杜威商量是否可行。下面是需求：</div></div>
+     <div class="rm-block-children">
+       <div class="roam-block-container">
+         <div class="rm-block-main" data-testid="child"><div class="controls"><span class="bp3-popover-target"><span class="rm-bullet"><span class="rm-bullet__inner"></span></span></span></div><div class="rm-block-text" data-testid="child-text">运动康复</div></div>
+       </div>
+     </div>
+   </div>
+
+  </div>
+ </div>
+</div>
+
+<script type="module">
+  import { addReferencePath, removeReferencePath, addStyle, internals } from '/extension.js';
+  window.__rp = { addReferencePath, removeReferencePath, addStyle, internals };
+  window.__rpReady = true;
+</script>
+</body>
+</html>

--- a/test/fixtures/roam-scroll.html
+++ b/test/fixtures/roam-scroll.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>reference-path scroll fixture</title>
+<style>
+  * { box-sizing: content-box; }
+  body { margin: 0; padding: 20px; font-family: sans-serif; }
+  .rm-block-children { margin-left: 24px; }
+  .rm-block-main {
+    position: relative; display: flex; align-items: flex-start;
+    padding: 0; border: 0; margin: 0;
+  }
+  .rm-block-main > .controls {
+    flex: 0 0 12px; width: 12px; height: 20px;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .rm-block-main.rm-heading-level-1 > .controls { height: 48px; }
+  .controls span.bp3-popover-target { display: inline-block; width: 12px; height: 12px; }
+  .controls span.rm-bullet { display: flex; align-items: center; justify-content: center; width: 12px; height: 12px; }
+  .controls span.rm-bullet__inner { width: 6px; height: 6px; border-radius: 50%; background: #a3a3a3; }
+  .rm-block-text { line-height: 20px; font-size: 14px; padding: 0; }
+  .rm-heading-level-1 .rm-block-text { line-height: 48px; font-size: 30px; font-weight: 700; }
+  .rm-block-text textarea { font: inherit; border: 0; padding: 0; margin: 0; width: 320px; resize: none; }
+</style>
+</head>
+<body>
+<div class="roam-main">
+ <div class="rm-article-wrapper">
+  <div class="roam-article">
+
+   <!-- parent (H1) -->
+   <div class="roam-block-container">
+     <div class="rm-block-main rm-heading-level-1" data-testid="parent">
+       <div class="controls"><span class="bp3-popover-target"><span class="rm-bullet"><span class="rm-bullet__inner"></span></span></span></div>
+       <div class="rm-block-text">CH2 卡片大法</div>
+     </div>
+     <div class="rm-block-children">
+
+       <!-- child = the ACTIVE / edited block, in edit mode (textarea present).
+            The textarea sits 3 levels under roam-block-container, matching Roam's
+            edit-mode structure that addReferencePath relies on. -->
+       <div class="roam-block-container">
+         <div class="rm-block-main" data-testid="child">
+           <div class="controls"><span class="bp3-popover-target"><span class="rm-bullet"><span class="rm-bullet__inner"></span></span></span></div>
+           <div class="rm-block-text"><textarea data-testid="active-textarea">组块：人类的大脑在意识层面，通过对组块来进行计算与排列组合，产生思想。</textarea></div>
+         </div>
+       </div>
+
+     </div>
+   </div>
+
+  </div>
+ </div>
+</div>
+
+<script type="module">
+  import { addReferencePath, removeReferencePath, addStyle, internals } from '/extension.js';
+  // startTemporaryObserver is internal; expose the whole module namespace instead
+  import * as ext from '/extension.js';
+  window.__rp = { addReferencePath, removeReferencePath, addStyle, internals, ext };
+  window.__rpReady = true;
+</script>
+</body>
+</html>

--- a/test/reference-path-layout.spec.js
+++ b/test/reference-path-layout.spec.js
@@ -1,0 +1,55 @@
+const { test, expect } = require('@playwright/test');
+
+// Regression test for the "母block排版改变" bug: adding the reference path to a
+// block must not change the block's own layout. The earlier fix forced
+// position:relative on the bullet, which in Roam is position:absolute (in the
+// gutter). That override pulled the bullet back into the flow and reflowed the
+// block. Here the fixture models the absolute bullet; highlighting must leave the
+// parent block's text exactly where it was.
+test('highlighting a block does not reflow it', async ({ page }) => {
+  await page.goto('/test/fixtures/roam-layout.html');
+  await page.waitForFunction(() => window.__rpReady === true);
+
+  const result = await page.evaluate(() => {
+    const { addReferencePath, addStyle, internals } = window.__rp;
+
+    Object.assign(internals.settingsCached, {
+      bulletColorHex: '#6366f1',
+      bulletColorHoverHex: '#818cf8',
+      bulletScaleFactor: '1.5',
+      referenceColorHex: 'disabled',
+      referenceFontWeightValue: 'disabled',
+      lineColorHex: '#6366f1',
+      lineColorHoverHex: '#818cf8',
+      lineWidth: '1px',
+      lineStyle: 'solid',
+      lineRoundness: '2px',
+      lineTopOffset: 'auto',
+      lineLeftOffset: 'auto',
+    });
+
+    addStyle();
+
+    const parentText = document.querySelector('[data-testid="parent-text"]');
+    const before = parentText.getBoundingClientRect();
+
+    // click/edit the child -> its ancestor path (incl. the parent) gets highlighted
+    const active = document.querySelector('[data-testid="child-text"]');
+    addReferencePath(internals.blockList.mainView, active);
+
+    const after = parentText.getBoundingClientRect();
+    const parent = document.querySelector('[data-testid="parent"]');
+
+    return {
+      highlighted: parent.dataset.referencePathHasStyle === 'true',
+      dLeft: after.left - before.left,
+      dWidth: after.width - before.width,
+    };
+  });
+
+  // the parent block really is on the path (so the styles applied to it)
+  expect(result.highlighted).toBe(true);
+  // ...yet its text did not move or resize
+  expect(Math.abs(result.dLeft)).toBeLessThan(0.5);
+  expect(Math.abs(result.dWidth)).toBeLessThan(0.5);
+});

--- a/test/reference-path-refs.spec.js
+++ b/test/reference-path-refs.spec.js
@@ -1,0 +1,48 @@
+const { test, expect } = require('@playwright/test');
+
+// Regression test for the reflow reported when clicking a child block: the
+// parent block contains references (a [[page]] link, a date). The extension used
+// to bump their font-weight to 'medium' on highlight; bolder text is wider, so a
+// reference near a line-wrap boundary pushed the following text onto a new line
+// (the "母block排版改变" the user saw). References are now emphasised with colour
+// only, so highlighting cannot change their width and the block cannot reflow.
+test('highlighting references changes colour but not width (no reflow)', async ({ page }) => {
+  await page.goto('/test/fixtures/roam-refs.html');
+  await page.waitForFunction(() => window.__rpReady === true);
+
+  const m = await page.evaluate(() => {
+    const { addReferencePath, addStyle, internals } = window.__rp;
+
+    Object.assign(internals.settingsCached, {
+      bulletColorHex: '#6366f1', bulletColorHoverHex: '#818cf8', bulletScaleFactor: '1.5',
+      referenceColorHex: '#6366f1', referenceColorHoverHex: '#818cf8',
+      lineColorHex: '#6366f1', lineColorHoverHex: '#818cf8',
+      lineWidth: '1px', lineStyle: 'solid', lineRoundness: '2px',
+      lineTopOffset: 'auto', lineLeftOffset: 'auto',
+    });
+
+    addStyle();
+
+    const text = document.querySelector('[data-testid="parent-text"]');
+    const ref = document.querySelector('[data-testid="ref"]');
+    const before = { h: text.getBoundingClientRect().height, refW: ref.getBoundingClientRect().width };
+
+    addReferencePath(internals.blockList.mainView, document.querySelector('[data-testid="child-text"]'));
+
+    const after = { h: text.getBoundingClientRect().height, refW: ref.getBoundingClientRect().width };
+    const parent = document.querySelector('[data-testid="parent"]');
+    return {
+      highlighted: parent.dataset.referencePathHasStyle === 'true',
+      refColor: getComputedStyle(ref).color,
+      dRefW: after.refW - before.refW,
+      dH: after.h - before.h,
+    };
+  });
+
+  expect(m.highlighted).toBe(true);
+  // the reference is still emphasised: it takes the theme colour (#6366f1)
+  expect(m.refColor).toBe('rgb(99, 102, 241)');
+  // ...but its width is unchanged, so the block cannot reflow
+  expect(Math.abs(m.dRefW)).toBeLessThan(0.5);
+  expect(Math.abs(m.dH)).toBeLessThan(0.5);
+});

--- a/test/reference-path-scroll.spec.js
+++ b/test/reference-path-scroll.spec.js
@@ -1,0 +1,62 @@
+const { test, expect } = require('@playwright/test');
+
+// The reference-path line is positioned from getBoundingClientRect measurements
+// taken when the path is drawn. Scrolling fires no DOM mutation, so without a
+// scroll handler the line is never recomputed and drifts out of alignment with
+// the bullets. This test drives the real observer + scroll handler and asserts a
+// scroll recomputes the geometry.
+test('reference path is recomputed on scroll', async ({ page }) => {
+  await page.goto('/test/fixtures/roam-scroll.html');
+  await page.waitForFunction(() => window.__rpReady === true);
+
+  const result = await page.evaluate(async () => {
+    const { addReferencePath, addStyle, internals, ext } = window.__rp;
+
+    Object.assign(internals.settingsCached, {
+      bulletColorHex: 'disabled',
+      bulletScaleFactor: 'disabled',
+      referenceColorHex: 'disabled',
+      referenceFontWeightValue: 'disabled',
+      lineColorHex: '#22c55e',
+      lineColorHoverHex: '#22c55e',
+      lineWidth: '1px',
+      lineStyle: 'solid',
+      lineRoundness: '2px',
+      lineTopOffset: 'auto',
+      lineLeftOffset: 'auto',
+    });
+
+    addStyle();
+
+    const target = document.querySelector('div.rm-article-wrapper');
+    // registers the real MutationObserver AND the scroll listener under test
+    ext.startTemporaryObserver({ target });
+
+    // draw the path from the edited block's textarea (edit mode)
+    const textarea = document.querySelector('[data-testid="active-textarea"]');
+    internals.isEditing.mainView = true;
+    addReferencePath(internals.blockList.mainView, textarea);
+
+    const parent = document.querySelector('[data-testid="parent"]');
+    const VAR = '--roam-reference-path-box-height';
+    const drawn = parent.style.getPropertyValue(VAR);
+
+    // simulate the line having gone stale (what a scroll leaves behind with no redraw)
+    parent.style.setProperty(VAR, '1px');
+    const corrupted = parent.style.getPropertyValue(VAR);
+
+    // a scroll must trigger a redraw that restores the correct geometry
+    window.dispatchEvent(new Event('scroll'));
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => requestAnimationFrame(r))));
+
+    const afterScroll = parent.style.getPropertyValue(VAR);
+
+    return { drawn, corrupted, afterScroll };
+  });
+
+  // the path was actually drawn (parent block got a real, positive box height)
+  expect(parseFloat(result.drawn)).toBeGreaterThan(0);
+  expect(result.corrupted).toBe('1px');
+  // scrolling restored the measured geometry -> redraw-on-scroll fired
+  expect(result.afterScroll).toBe(result.drawn);
+});

--- a/test/reference-path.spec.js
+++ b/test/reference-path.spec.js
@@ -1,0 +1,104 @@
+const { test, expect } = require('@playwright/test');
+
+// Tolerance in px. The bug offsets a heading connector by ~10-14px, so a 3px
+// tolerance cleanly separates "aligned" (fixed) from "misaligned" (original).
+const TOL = 3;
+
+// Runs the real extension code against the fixture DOM and reports, for each
+// drawn L-connector, where its endpoints land vs. the actual bullet centres.
+async function measure(page) {
+  await page.goto('/');
+  await page.waitForFunction(() => window.__rpReady === true);
+
+  return page.evaluate(() => {
+    const { addReferencePath, addStyle, internals } = window.__rp;
+
+    // seed only what the line drawing needs; disable the rest to isolate geometry
+    Object.assign(internals.settingsCached, {
+      bulletColorHex: 'disabled',
+      bulletScaleFactor: 'disabled',
+      referenceColorHex: 'disabled',
+      referenceFontWeightValue: 'disabled',
+      lineColorHex: '#22c55e',
+      lineColorHoverHex: '#22c55e',
+      lineWidth: '1px',
+      lineStyle: 'solid',
+      lineRoundness: '2px',
+      lineTopOffset: 'auto',
+      lineLeftOffset: 'auto',
+    });
+
+    addStyle(); // inject the real ::before CSS rule under test
+    const active = document.querySelector('[data-testid="active-text"]');
+    addReferencePath(internals.blockList.mainView, active);
+
+    const bulletCenter = (main) => {
+      const r = main.querySelector('span.bp3-popover-target').getBoundingClientRect();
+      return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+    };
+
+    // Reconstruct the ::before box in viewport coords. The ::before is positioned
+    // against its containing block: the bullet span itself if positioned,
+    // otherwise the span's offsetParent. This stays correct across both the
+    // original code (offsetParent = rm-block-main) and the fix (span is relative).
+    const beforeBox = (main) => {
+      const span = main.querySelector('span.bp3-popover-target');
+      const cs = getComputedStyle(span, '::before');
+      const origin = getComputedStyle(span).position !== 'static' ? span : span.offsetParent;
+      const o = origin.getBoundingClientRect();
+      const top = parseFloat(cs.top), left = parseFloat(cs.left);
+      const w = parseFloat(cs.width), h = parseFloat(cs.height);
+      return { top: o.top + top, left: o.left + left, bottom: o.top + top + h, right: o.left + left + w };
+    };
+
+    const ch2 = document.querySelector('[data-testid="ch2"]');
+    const pinjie = document.querySelector('[data-testid="pinjie"]');
+    const kuoxie = document.querySelector('[data-testid="kuoxie"]');
+    const xijie = document.querySelector('[data-testid="xijie"]');
+
+    return {
+      // hop parent -> child (the L is drawn on the parent's bullet)
+      hop_kuoxie_to_xijie: {
+        parent: 'kuoxie(normal)', child: 'xijie(normal)',
+        parentCenter: bulletCenter(kuoxie), childCenter: bulletCenter(xijie),
+        box: beforeBox(kuoxie), styled: kuoxie.dataset.referencePathHasStyle === 'true',
+      },
+      hop_pinjie_to_kuoxie: {
+        parent: 'pinjie(H2)', child: 'kuoxie(normal)',
+        parentCenter: bulletCenter(pinjie), childCenter: bulletCenter(kuoxie),
+        box: beforeBox(pinjie), styled: pinjie.dataset.referencePathHasStyle === 'true',
+      },
+      hop_ch2_to_pinjie: {
+        parent: 'ch2(H1)', child: 'pinjie(H2)',
+        parentCenter: bulletCenter(ch2), childCenter: bulletCenter(pinjie),
+        box: beforeBox(ch2), styled: ch2.dataset.referencePathHasStyle === 'true',
+      },
+      initialBlockStyled: xijie.dataset.referencePathHasStyle === 'true',
+    };
+  });
+}
+
+function expectConnectorAligned(hop) {
+  expect(hop.styled, `${hop.parent} should be on the path`).toBe(true);
+  // L starts at the parent bullet centre
+  expect(Math.abs(hop.box.top - hop.parentCenter.y),
+    `${hop.parent}: connector top (${hop.box.top.toFixed(1)}) should meet parent bullet centre (${hop.parentCenter.y.toFixed(1)})`).toBeLessThanOrEqual(TOL);
+  expect(Math.abs(hop.box.left - hop.parentCenter.x),
+    `${hop.parent}: connector left should meet parent bullet centre x`).toBeLessThanOrEqual(TOL);
+  // L ends at the child bullet centre
+  expect(Math.abs(hop.box.bottom - hop.childCenter.y),
+    `${hop.parent}->${hop.child}: connector bottom (${hop.box.bottom.toFixed(1)}) should meet child bullet centre (${hop.childCenter.y.toFixed(1)})`).toBeLessThanOrEqual(TOL);
+  expect(Math.abs(hop.box.right - hop.childCenter.x),
+    `${hop.parent}->${hop.child}: connector right should meet child bullet centre x`).toBeLessThanOrEqual(TOL);
+}
+
+test('reference-path connectors align with bullet centres on heading blocks', async ({ page }) => {
+  const m = await measure(page);
+
+  // the deepest (active) block is the initial block: it must be marked but draws no line
+  expect(m.initialBlockStyled).toBe(true);
+
+  expectConnectorAligned(m.hop_kuoxie_to_xijie); // normal -> normal (no-regression control)
+  expectConnectorAligned(m.hop_pinjie_to_kuoxie); // heading -> normal
+  expectConnectorAligned(m.hop_ch2_to_pinjie);    // heading -> heading
+});

--- a/test/static-server.mjs
+++ b/test/static-server.mjs
@@ -1,0 +1,36 @@
+// Tiny zero-dependency static file server used by the Playwright webServer.
+// ES-module imports (extension.js) are blocked by the browser over file://,
+// so the fixture must be served over http.
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = normalize(join(fileURLToPath(import.meta.url), '..', '..')); // repo root
+const port = process.env.PORT ? Number(process.env.PORT) : 5599;
+
+const types = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.png': 'image/png',
+};
+
+const server = http.createServer(async (req, res) => {
+  try {
+    let urlPath = decodeURIComponent(req.url.split('?')[0]);
+    if (urlPath === '/') urlPath = '/test/fixtures/roam-outline.html';
+    const filePath = normalize(join(root, urlPath));
+    if (filePath !== root && !filePath.startsWith(root + sep)) {
+      res.writeHead(403); res.end('forbidden'); return;
+    }
+    const body = await readFile(filePath);
+    res.writeHead(200, { 'content-type': types[extname(filePath)] || 'application/octet-stream' });
+    res.end(body);
+  } catch (err) {
+    res.writeHead(404); res.end('not found: ' + err.message);
+  }
+});
+
+server.listen(port, () => console.log(`static server: http://localhost:${port} (root=${root})`));


### PR DESCRIPTION
Fixes for reference-path line alignment. All runtime changes are isolated to `extension.js`; the rest is an additive Playwright test harness (`npm test`).

## 1. Misalignment on heading / tall blocks

**Problem:** when a block in the path is a heading (h1/h2/h3) — or has tall content such as an embedded image — the connector's start point / corner is drawn several pixels above the actual bullet.

**Cause:** the connector was positioned with fixed constants (`getLineTopOffsetAuto` → `9.5px`, `getLineLeftOffsetAuto` → `6px`) and box dimensions measured from each block's `rm-block-main` top-left corner. Those constants assume a normal single-line text block; on a heading block the bullet centre sits ~20px below the block top, so the line is ~10px off.

**Fix:** measure the actual bullet elements (`span.bp3-popover-target`) and draw the connector from the parent bullet **centre** to the child bullet **centre**. The corner offset is computed against the bullet's real containing block, measured at runtime — **without changing any element's `position`** (see #2). Theme-agnostic, so the Roam-Studio-specific offset constants are removed. The ADVANCED manual offsets still override `auto`.

## 2. Block reflow when highlighted

**Problem:** clicking a block visibly shifts/reflows the block (the parent's text wraps onto an extra line, and the connector is knocked out of alignment).

**Cause (two contributions):**
1. an early version of fix #1 forced `position: relative` on the bullet. Roam positions that bullet `absolute` in the gutter, out of the flow; overriding it to `relative` pulls it back into the flow and pushes the checkbox/text right.
2. references in a path block were bolded (`font-weight`, default *medium*). Bolder text is wider, so a reference near a line-wrap boundary pushes the following text onto another line.

**Fix:**
1. never change the bullet's `position`; measure whatever the real containing block is (the bullet itself when Roam positions it, otherwise its offset parent) and offset the corner relative to that.
2. drop the reference `font-weight` emphasis (and its setting); references still stand out via the colour change, which does not affect layout.

Highlighting a block now changes zero width-affecting properties, so it can no longer reflow.

## 3. Drift after scrolling

**Problem:** after clicking a block and scrolling, the line drifts out of alignment.

**Cause:** the geometry is measured with `getBoundingClientRect` at draw time, and the path was only redrawn on DOM mutations. Scrolling fires no mutation.

**Fix:** a capture-phase `window` scroll listener (catches the main view and the sidebar) recomputes the active path, throttled to one redraw per animation frame, while a block is being edited. Cleaned up with the temporary observer.

## Tests

Playwright + synthetic Roam DOM fixtures (no Roam login; real browser layout via the locally installed Chrome). Each fails on the corresponding pre-fix code:

- connector endpoints land on bullet centres for normal→normal, heading→normal and heading→heading hops;
- highlighting a block does not move the parent block's text (bullet stays out of flow);
- highlighting a reference changes its colour but not its width (no reflow);
- a scroll event recomputes the connector geometry.

```
npm install
npm test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
